### PR TITLE
Add card showing the top components with most interactions

### DIFF
--- a/frontends/dashboard/src/analytics/api/topComponents.ts
+++ b/frontends/dashboard/src/analytics/api/topComponents.ts
@@ -1,0 +1,40 @@
+import { AnalyticsFilter, TopComponent } from "shared/types";
+import { transformAnalyticsFilter } from "../utils/formatDate";
+
+const apiHost = import.meta.env.VITE_API_HOST as string;
+
+export const getTopComponents = async (
+  filters: AnalyticsFilter,
+  datasetId: string,
+): Promise<TopComponent[]> => {
+  // This is a mock implementation until the backend endpoint is created
+  // Eventually this will fetch real data from:
+  // ${apiHost}/analytics/components
+  
+  // For now, we're returning mock data that represents the top components by interaction count
+  // This will be replaced with actual API call once the backend is implemented
+  const mockData: TopComponent[] = [
+    {
+      component_name: "SearchInput",
+      interaction_count: 1245,
+    },
+    {
+      component_name: "ResultList",
+      interaction_count: 982,
+    },
+    {
+      component_name: "FilterDropdown",
+      interaction_count: 734,
+    },
+    {
+      component_name: "ChatWidget",
+      interaction_count: 521,
+    },
+    {
+      component_name: "PaginationControls",
+      interaction_count: 403,
+    },
+  ];
+
+  return mockData;
+};

--- a/frontends/dashboard/src/analytics/components/charts/TopComponents.tsx
+++ b/frontends/dashboard/src/analytics/components/charts/TopComponents.tsx
@@ -1,0 +1,68 @@
+import { TopComponent } from "shared/types";
+import { getTopComponents } from "../../api/topComponents";
+import { useDatasetContext } from "../../../contexts/DatasetContext";
+import { AnalyticsParams } from "shared/types";
+import { createResource, For, Show } from "solid-js";
+import { MagicSuspense } from "../../../components/MagicBox";
+
+interface TopComponentsProps {
+  params: Pick<AnalyticsParams, "filter">;
+}
+
+export const TopComponents = (props: TopComponentsProps) => {
+  const datasetContext = useDatasetContext();
+  const dataset = datasetContext?.dataset;
+
+  const [topComponents] = createResource(
+    () => ({
+      filter: props.params.filter,
+      datasetId: dataset?.id || "",
+    }),
+    async ({ filter, datasetId }) => {
+      if (!datasetId) return [];
+      return await getTopComponents(filter, datasetId);
+    }
+  );
+
+  return (
+    <MagicSuspense fallback={<div>Loading top components...</div>}>
+      <div class="flex flex-col space-y-4 py-2">
+        <Show when={!topComponents.loading && topComponents()?.length === 0}>
+          <div class="text-center text-gray-500 dark:text-gray-400">
+            No component interactions found in the selected time period.
+          </div>
+        </Show>
+        <Show when={!topComponents.loading && topComponents()?.length}>
+          <div class="overflow-x-auto">
+            <table class="w-full text-left">
+              <thead>
+                <tr class="border-b border-gray-200 dark:border-gray-700">
+                  <th class="pb-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+                    Component
+                  </th>
+                  <th class="pb-2 text-right text-sm font-normal text-gray-500 dark:text-gray-400">
+                    Interactions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={topComponents()}>
+                  {(component: TopComponent) => (
+                    <tr class="border-b border-gray-100 dark:border-gray-800">
+                      <td class="py-3 text-sm font-medium">
+                        {component.component_name}
+                      </td>
+                      <td class="py-3 text-right text-sm">
+                        {component.interaction_count.toLocaleString()}
+                      </td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
+          </div>
+        </Show>
+      </div>
+    </MagicSuspense>
+  );
+};

--- a/frontends/dashboard/src/analytics/pages/AnalyticsOverviewPage.tsx
+++ b/frontends/dashboard/src/analytics/pages/AnalyticsOverviewPage.tsx
@@ -3,6 +3,7 @@ import { Card } from "../components/charts/Card";
 import { HeadQueries } from "../components/charts/HeadQueries";
 import { QueryCounts } from "../components/charts/QueryCounts";
 import { SearchUsageGraph } from "../components/charts/SearchUsageGraph";
+import { TopComponents } from "../components/charts/TopComponents";
 import { CTRInfoPanel } from "../components/CTRInfoPanel";
 import { DateRangeFilter } from "shared/types";
 import { createSignal } from "solid-js";
@@ -21,6 +22,10 @@ export const AnalyticsOverviewPage = () => {
 
   const [headQueriesDate, setHeadQueriesDate] = createSignal<DateRangeFilter>({
     gt: subHours(new Date(), 1),
+  });
+
+  const [topComponentsDate, setTopComponentsDate] = createSignal<DateRangeFilter>({
+    gt: subMonths(new Date(), 1),
   });
 
   return (
@@ -74,6 +79,25 @@ export const AnalyticsOverviewPage = () => {
           <HeadQueries
             params={{
               filter: { date_range: headQueriesDate() },
+            }}
+          />
+        </Card>
+
+        <Card
+          controller={
+            <DateRangePicker
+              onChange={(e) => setTopComponentsDate(e)}
+              initialSelectedPresetId={3}
+              value={topComponentsDate()}
+            />
+          }
+          title="Top Components"
+          class="px-4"
+          width={1}
+        >
+          <TopComponents
+            params={{
+              filter: { date_range: topComponentsDate() },
             }}
           />
         </Card>

--- a/frontends/shared/types.ts
+++ b/frontends/shared/types.ts
@@ -462,6 +462,11 @@ export interface RangeFilter {
   lte?: number;
 }
 
+export interface TopComponent {
+  component_name: string;
+  interaction_count: number;
+}
+
 export interface AnalyticsFilter {
   date_range: DateRangeFilter;
   search_method?: "fulltext" | "hybrid" | "semantic";


### PR DESCRIPTION
This PR adds a new card to the Analytics Overview page that displays the top components with the most interactions.